### PR TITLE
Implement productExceptSelf function to calculate the product of array except self

### DIFF
--- a/src/array/product_of_array_except_self.py
+++ b/src/array/product_of_array_except_self.py
@@ -35,8 +35,20 @@ class Solution:
         Time Complexity: O(?)
         Space Complexity: O(?)
         """
-        # TODO: Implement solution
-        pass
+        size = len(nums)
+        prods = [1]*size
+
+        prod = nums[0]
+        for i in range(1,size):
+            prods[i] *= prod
+            prod *= nums[i]
+        
+        prod = nums[size-1]
+        for i in reversed(range(0, size-1)):
+            prods[i] *= prod
+            prod *= nums[i]
+
+        return prods
 
 
 # Example usage (for testing locally)


### PR DESCRIPTION
This pull request implements the solution for the `productExceptSelf` function in `product_of_array_except_self.py`. The function now correctly computes the product of all elements in the array except for the current index, without using division and in linear time.

Implementation of core algorithm:

* Fully implemented the `productExceptSelf` function to compute the product of all elements except self using prefix and suffix products, achieving O(n) time and O(n) space complexity.