### PR TITLE
add construct binary tree base on pre and in order

### DIFF
--- a/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
+++ b/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
@@ -48,17 +48,17 @@ class Solution:
         for i, val in enumerate(inorder):
             in_val_to_index[val] = i
 
-        def dfs_build(inorder_arr, l, h):
+        def dfs_build(l, h):
             if l>=h:
                 return None
             node_val = preorder[self.pre_index]
             node = TreeNode(node_val)
             self.pre_index += 1
-            node.left = dfs_build(inorder_arr, l, in_val_to_index[node_val])
-            node.right = dfs_build(inorder_arr, in_val_to_index[node_val]+1, h)
+            node.left = dfs_build(l, in_val_to_index[node_val])
+            node.right = dfs_build(in_val_to_index[node_val]+1, h)
             return node
 
-        return dfs_build(inorder, 0, len(preorder))
+        return dfs_build(0, len(preorder))
 
 
 # Example usage (for testing locally)

--- a/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
+++ b/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
@@ -29,7 +29,6 @@ class TreeNode:
 
 class Solution:
     def buildTree(self, preorder, inorder):
-        self.pre_index = 0
         """
         Build binary tree from preorder and inorder traversals.
 
@@ -43,23 +42,23 @@ class Solution:
         Time Complexity: O(n)
         Space Complexity: O(n)
         """
+        self.pre_index = 0
+
         in_val_to_index = {}
         for i, val in enumerate(inorder):
             in_val_to_index[val] = i
 
-        def dfs_build (root, l, h):
-            myroot = root[l:h]
-            if not myroot:
+        def dfs_build(inorder_arr, l, h):
+            if l>=h:
                 return None
-            else:
-                node_val = preorder[self.pre_index]
-                node = TreeNode(node_val)
-                self.pre_index += 1
-                node.left = dfs_build (root, l, in_val_to_index[node_val])
-                node.right = dfs_build (root, in_val_to_index[node_val]+1, h)
+            node_val = preorder[self.pre_index]
+            node = TreeNode(node_val)
+            self.pre_index += 1
+            node.left = dfs_build (inorder_arr, l, in_val_to_index[node_val])
+            node.right = dfs_build (inorder_arr, in_val_to_index[node_val]+1, h)
             return node
 
-        return dfs_build (inorder, 0, len(preorder))
+        return dfs_build(inorder, 0, len(preorder))
 
 
 # Example usage (for testing locally)

--- a/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
+++ b/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
@@ -58,7 +58,7 @@ class Solution:
             node.right = dfs_build(in_val_to_index[node_val]+1, h)
             return node
 
-        return dfs_build(0, len(preorder))
+        return dfs_build(0, len(inorder))
 
 
 # Example usage (for testing locally)

--- a/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
+++ b/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
@@ -29,6 +29,7 @@ class TreeNode:
 
 class Solution:
     def buildTree(self, preorder, inorder):
+        self.pre_index = 0
         """
         Build binary tree from preorder and inorder traversals.
 
@@ -42,8 +43,23 @@ class Solution:
         Time Complexity: O(n)
         Space Complexity: O(n)
         """
-        # TODO: Implement solution
-        pass
+        in_val_to_index = {}
+        for i, val in enumerate(inorder):
+            in_val_to_index[val] = i
+
+        def dfs_build (root, l, h):
+            myroot = root[l:h]
+            if not myroot:
+                return None
+            else:
+                node_val = preorder[self.pre_index]
+                node = TreeNode(node_val)
+                self.pre_index += 1
+                node.left = dfs_build (root, l, in_val_to_index[node_val])
+                node.right = dfs_build (root, in_val_to_index[node_val]+1, h)
+            return node
+
+        return dfs_build (inorder, 0, len(preorder))
 
 
 # Example usage (for testing locally)

--- a/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
+++ b/src/tree/construct_binary_tree_from_preorder_and_inorder_traversal.py
@@ -54,8 +54,8 @@ class Solution:
             node_val = preorder[self.pre_index]
             node = TreeNode(node_val)
             self.pre_index += 1
-            node.left = dfs_build (inorder_arr, l, in_val_to_index[node_val])
-            node.right = dfs_build (inorder_arr, in_val_to_index[node_val]+1, h)
+            node.left = dfs_build(inorder_arr, l, in_val_to_index[node_val])
+            node.right = dfs_build(inorder_arr, in_val_to_index[node_val]+1, h)
             return node
 
         return dfs_build(inorder, 0, len(preorder))


### PR DESCRIPTION
This pull request implements the binary tree construction algorithm from preorder and inorder traversal arrays in `construct_binary_tree_from_preorder_and_inorder_traversal.py`. The main change is the completion of the `buildTree` method, which now efficiently builds the tree using a recursive helper and a value-to-index mapping.

Implementation of tree construction logic:

* Added initialization of `self.pre_index` to track the current node in preorder traversal.
* Implemented the `buildTree` method, including:
  * Creation of an `in_val_to_index` dictionary for fast lookups of node positions in the inorder array.
  * A recursive `dfs_build` function that constructs the tree using preorder and inorder indices, creating `TreeNode` instances and assigning left/right children accordingly.