### PR TITLE
Implement numIslands function to count islands in a grid

### DIFF
--- a/src/graph/number_of_islands.py
+++ b/src/graph/number_of_islands.py
@@ -36,8 +36,30 @@ class Solution:
         Time Complexity: O(m * n)
         Space Complexity: O(m * n) for recursion stack
         """
-        # TODO: Implement solution
-        pass
+        row_num = len(grid)
+        col_num = len(grid[0])
+        visit_record = []
+        num_island = 0
+
+        def dfs(i, j):
+            if (i,j) not in visit_record and grid[i][j] == "1":
+                visit_record.append((i, j))
+                if 0<=i-1<row_num:
+                    dfs(i-1, j)
+                if 0<=i+1<row_num:
+                    dfs(i+1, j)
+                if 0<=j-1<col_num:
+                    dfs(i, j-1)
+                if 0<=j+1<col_num:
+                    dfs(i, j+1)
+
+        for i in range(0, len(grid)):
+            for j in range(0, len(grid[0])):
+                if (i,j) not in visit_record and grid[i][j] == "1":
+                    num_island += 1
+                    dfs(i, j)
+
+        return num_island
 
 
 # Example usage (for testing locally)

--- a/src/graph/number_of_islands.py
+++ b/src/graph/number_of_islands.py
@@ -38,12 +38,12 @@ class Solution:
         """
         row_num = len(grid)
         col_num = len(grid[0])
-        visit_record = []
+        visit_record = set()
         num_island = 0
 
         def dfs(i, j):
             if (i,j) not in visit_record and grid[i][j] == "1":
-                visit_record.append((i, j))
+                visit_record.add((i, j))
                 if 0<=i-1<row_num:
                     dfs(i-1, j)
                 if 0<=i+1<row_num:
@@ -53,8 +53,8 @@ class Solution:
                 if 0<=j+1<col_num:
                     dfs(i, j+1)
 
-        for i in range(0, len(grid)):
-            for j in range(0, len(grid[0])):
+        for i in range(0, row_num):
+            for j in range(0, col_num):
                 if (i,j) not in visit_record and grid[i][j] == "1":
                     num_island += 1
                     dfs(i, j)

--- a/src/graph/number_of_islands.py
+++ b/src/graph/number_of_islands.py
@@ -36,15 +36,18 @@ class Solution:
         Time Complexity: O(m * n)
         Space Complexity: O(m * n) for recursion stack
         """
+        if not grid or not grid[0]:
+            return 0
+
         row_num = len(grid)
         col_num = len(grid[0])
         visit_record = set()
         num_island = 0
+        directions = [(-1, 0), (1, 0), (0, 1), (0, -1)]
 
         def dfs(i, j):
             if (i,j) not in visit_record and grid[i][j] == "1":
                 visit_record.add((i, j))
-                directions = [(-1, 0), (1, 0), (0, 1), (0, -1)]
                 for di, dj in directions:
                     next_i, next_j = i + di, j + dj
                     if 0 <= next_i < row_num and 0 <= next_j < col_num:

--- a/src/graph/number_of_islands.py
+++ b/src/graph/number_of_islands.py
@@ -44,14 +44,11 @@ class Solution:
         def dfs(i, j):
             if (i,j) not in visit_record and grid[i][j] == "1":
                 visit_record.add((i, j))
-                if 0<=i-1<row_num:
-                    dfs(i-1, j)
-                if 0<=i+1<row_num:
-                    dfs(i+1, j)
-                if 0<=j-1<col_num:
-                    dfs(i, j-1)
-                if 0<=j+1<col_num:
-                    dfs(i, j+1)
+                directions = [(-1, 0), (1, 0), (0, 1), (0, -1)]
+                for di, dj in directions:
+                    next_i, next_j = i + di, j + dj
+                    if 0 <= next_i < row_num and 0 <= next_j < col_num:
+                        dfs(next_i, next_j)
 
         for i in range(0, row_num):
             for j in range(0, col_num):


### PR DESCRIPTION
This pull request implements the solution for counting the number of islands in a grid using depth-first search (DFS) in the `numIslands` function. The previously unimplemented method now tracks visited cells and recursively explores connected land cells.

Implementation of DFS-based island counting:

* Added a DFS helper function to recursively explore connected land cells, marking them as visited in `visit_record`.
* Updated the main logic to iterate through the grid, incrementing the island count for each unvisited land cell and invoking DFS to mark all connected cells.
* Replaced the placeholder `pass` statement with the complete solution and returned the final count of islands.