### PR TITLE
Implement cloneGraph method to deep copy an undirected graph

### DIFF
--- a/src/graph/clone_graph.py
+++ b/src/graph/clone_graph.py
@@ -27,7 +27,7 @@ class Node:
 
 
 class Solution:
-    def cloneGraph(self, node):
+    def cloneGraph(self, source):
         """
         Clone an undirected graph.
 
@@ -40,8 +40,25 @@ class Solution:
         Time Complexity: O(N + E) where N is number of nodes and E is edges
         Space Complexity: O(N) for the hashmap
         """
-        # TODO: Implement solution
-        pass
+        if not source:
+            return
+
+        visited = {}
+
+        def dfs(node):
+            if node.val in visited:
+                return visited[node.val]
+
+            new_node = Node(node.val)
+            new_neighbors = []
+            visited[node.val] = new_node
+            for neighbor in node.neighbors:
+                new_neighbors.append(dfs(neighbor))
+            new_node.neighbors = new_neighbors
+
+            return new_node
+
+        return dfs(source)
 
 
 # Example usage (for testing locally)


### PR DESCRIPTION
This pull request implements the solution for cloning an undirected graph in the `cloneGraph` method of the `Solution` class. The method now uses a depth-first search (DFS) approach with a hashmap to track visited nodes, ensuring that each node is cloned only once and that cycles are handled correctly.

Implementation of graph cloning:

* Replaced the placeholder implementation in `cloneGraph` with a working DFS-based solution that clones the graph, using a `visited` dictionary to avoid duplicating nodes and to handle cycles.
* Renamed the method parameter from `node` to `source` for clarity and consistency throughout the method.