### PR TITLE
Fix count initialization in valid_tree_union_find and adjust node count check

### DIFF
--- a/src/graph/graph_valid_tree.py
+++ b/src/graph/graph_valid_tree.py
@@ -105,7 +105,8 @@ class Solution:
 
     def valid_tree_union_find(self, n, edges):
         parent = [i for i in range(n)]
-        count = [1]
+        # number of nodes join
+        count = [0]
 
         def find(x):
             if x != parent[x]:
@@ -128,7 +129,8 @@ class Solution:
             if is_cycle:
                 return False
         
-        if count[0] != n:
+        num_of_nodes = count[0] + 1
+        if num_of_nodes != n:
             return False
 
         return True


### PR DESCRIPTION
This pull request makes a minor adjustment to the union-find implementation in `src/graph/graph_valid_tree.py` to improve correctness in counting the number of connected nodes when validating if a graph is a tree.

* Changed the initialization of the `count` variable from `[1]` to `[0]` to more accurately represent the number of joined nodes at the start.
* Updated the tree validation logic to use `num_of_nodes = count[0] + 1` when checking if all nodes are connected, ensuring the correct node count is compared against `n`.