### PR TITLE
Implement longestPalindrome method to find the longest palindromic substring

### DIFF
--- a/src/string/longest_palindromic_substring.py
+++ b/src/string/longest_palindromic_substring.py
@@ -34,7 +34,7 @@ class Solution:
         """
         size = len(s)
 
-        def find_palindromic_str(left, right):
+        def expand_around_center(left, right):
             while (left >= 0 and right < size and s[left] == s[right]):
                 left -= 1
                 right += 1
@@ -43,12 +43,12 @@ class Solution:
         result  = 0, 0
         for i in range(0, size):
             # examine palindrome in odd case
-            left, right = find_palindromic_str(i-1, i+1)
+            left, right = expand_around_center(i-1, i+1)
             if(right-left) > (result[1] - result[0]):
                 result = left, right
 
             # examine palindrome in even case
-            left, right = find_palindromic_str(i, i+1)
+            left, right = expand_around_center(i, i+1)
             if(right-left) > (result[1] - result[0]):
                 result = left, right
 

--- a/src/string/longest_palindromic_substring.py
+++ b/src/string/longest_palindromic_substring.py
@@ -32,9 +32,27 @@ class Solution:
         Time Complexity: O(n^2)
         Space Complexity: O(1)
         """
-        # TODO: Implement solution
-        pass
+        size = len(s)
 
+        def find_palindromic_str(left, right):
+            while (left >= 0 and right < size and s[left] == s[right]):
+                left -= 1
+                right += 1
+            return left+1, right-1
+
+        result  = 0, 0
+        for i in range(0, size):
+            # examine palindrome in odd case
+            left, right = find_palindromic_str(i-1, i+1)
+            if(right-left) > (result[1] - result[0]):
+                result = left, right
+
+            # examine palindrome in even case
+            left, right = find_palindromic_str(i, i+1)
+            if(right-left) > (result[1] - result[0]):
+                result = left, right
+
+        return s[result[0]:(result[1]+1)]
 
 # Example usage (for testing locally)
 if __name__ == "__main__":

--- a/src/string/longest_palindromic_substring.py
+++ b/src/string/longest_palindromic_substring.py
@@ -43,7 +43,7 @@ class Solution:
         result  = 0, 0
         for i in range(0, size):
             # examine palindrome in odd case
-            left, right = expand_around_center(i-1, i+1)
+            left, right = expand_around_center(i, i)
             if(right-left) > (result[1] - result[0]):
                 result = left, right
 


### PR DESCRIPTION
This pull request implements the `longestPalindrome` method in `longest_palindromic_substring.py`, replacing the previous placeholder code with a working solution that finds the longest palindromic substring in a given string using the expand-around-center approach.

Algorithm implementation:

* Implemented the expand-around-center algorithm in the `longestPalindrome` method, which efficiently finds the longest palindromic substring by checking both odd and even-length centers.
* Removed the placeholder `pass` statement and added the helper function `expand_around_center` for clarity and modularity.
* Updated the method to return the actual longest palindromic substring rather than a placeholder.