### PR TITLE
Implement minMeetingRooms method to calculate minimum conference rooms required

### DIFF
--- a/src/interval/meeting_rooms_ii.py
+++ b/src/interval/meeting_rooms_ii.py
@@ -17,6 +17,7 @@ Constraints:
 - 0 <= starti < endi <= 10^6
 """
 
+import heapq
 
 class Solution:
     def minMeetingRooms(self, intervals):
@@ -32,8 +33,17 @@ class Solution:
         Time Complexity: O(n log n)
         Space Complexity: O(n)
         """
-        # TODO: Implement solution
-        pass
+        intervals.sort(key=lambda x:x[0])
+        size = len(intervals)
+        h = [intervals[0][1]]
+
+        for s, e in intervals[1:size]:
+            if s >= h[0]:
+                heapq.heapreplace(h, e)
+            else:
+                heapq.heappush(h, e)
+                
+        return len(h)
 
 
 # Example usage (for testing locally)
@@ -47,3 +57,7 @@ if __name__ == "__main__":
     # Test case 2
     result = solution.minMeetingRooms([[7, 10], [2, 4]])
     print(f"Test 2: {result}")
+
+    # Test case 3
+    result = solution.minMeetingRooms([[1,5],[2,6],[3,7],[4,8],[5,9]])
+    print(f"Test 3: {result}")


### PR DESCRIPTION
This pull request implements the solution for the `minMeetingRooms` function in `meeting_rooms_ii.py`, which calculates the minimum number of meeting rooms required for a set of intervals. The main changes include implementing the heap-based algorithm, adding the necessary import, and expanding the test coverage.

Implementation of meeting room calculation:

* Implemented the `minMeetingRooms` function using a min-heap to efficiently track end times and determine the minimum number of rooms needed. The function sorts the intervals, uses a heap to manage ongoing meetings, and returns the required room count.
* Added the `heapq` import to support the heap operations used in the solution.

Testing improvements:

* Added a new test case to the example usage to further validate the solution with overlapping intervals.