### PR TITLE
Implement removeNthFromEnd method to remove the nth node from the end of the linked list

### DIFF
--- a/src/linked_list/remove_nth_node_from_end_of_list.py
+++ b/src/linked_list/remove_nth_node_from_end_of_list.py
@@ -40,8 +40,24 @@ class Solution:
         Time Complexity: O(L) where L is length of list
         Space Complexity: O(1)
         """
-        # TODO: Implement solution
-        pass
+        dummy = ListNode(next=head)
+        fast, slow = dummy, dummy
+        i = 0
+        while fast:
+            if i > n:
+                slow = slow.next
+            fast = fast.next
+            i += 1
+
+        if slow and slow.next:
+            slow.next = slow.next.next
+
+        return dummy.next
+
+    def pretty_print(self, list_ln):
+        while list_ln:
+            print(list_ln.val)
+            list_ln = list_ln.next
 
 
 # Example usage (for testing locally)
@@ -51,9 +67,9 @@ if __name__ == "__main__":
     # Test case 1
     head = ListNode(1, ListNode(2, ListNode(3, ListNode(4, ListNode(5)))))
     result = solution.removeNthFromEnd(head, 2)
-    print(f"Test 1: {result.val if result else None}")
+    solution.pretty_print(result)
 
     # Test case 2
     head = ListNode(1)
     result = solution.removeNthFromEnd(head, 1)
-    print(f"Test 2: {result}")
+    solution.pretty_print(result)


### PR DESCRIPTION
This pull request implements the `removeNthFromEnd` method for removing the N-th node from the end of a linked list and improves the test output for easier debugging and validation. The main changes are grouped into implementation of the algorithm and enhancements to test output.

**Implementation of algorithm:**

* Implemented the `removeNthFromEnd` method using a two-pointer approach with a dummy node to handle edge cases efficiently, replacing the previous placeholder code.

**Test output enhancements:**

* Added a `pretty_print` method to the class for printing linked list values, and updated test cases to use this method for clearer output of results. [[1]](diffhunk://#diff-fedc6b8a497b81e04ae7470ba81a8e29db8c99138fcb07396df15e176fb09921L43-R60) [[2]](diffhunk://#diff-fedc6b8a497b81e04ae7470ba81a8e29db8c99138fcb07396df15e176fb09921L54-R75)